### PR TITLE
Fix bug when no new_tokens exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<h1 align="center">Salve v0.7.0</h1>
+<h1 align="center">Salve v0.7.1</h1>
 
 # Installation
 

--- a/salve_ipc/server_functions/highlight/highlight.py
+++ b/salve_ipc/server_functions/highlight/highlight.py
@@ -50,7 +50,7 @@ def get_highlights(
                 # Lexer adds the newline back as its own token
                 continue
 
-            if not token_str.strip() and new_type == "Text":
+            if not token_str.strip() or new_type == "Text":
                 # If the token is empty or is plain Text we simply skip it because thats ultimately useless info
                 start_index = (start_index[0], start_index[1] + token_len)
                 continue

--- a/salve_ipc/server_functions/highlight/tokens.py
+++ b/salve_ipc/server_functions/highlight/tokens.py
@@ -103,6 +103,9 @@ def merge_tokens(tokens: list[Token]) -> list[Token]:
 
 
 def overwrite_tokens(old_tokens: list[Token], new_tokens: list[Token]):
+    if not new_tokens:
+        return old_tokens
+
     output_tokens: list[Token] = []
     dont_add_tokens: list[Token] = []
     for new_token in new_tokens:

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as file:
 
 setup(
     name="salve_ipc",
-    version="0.7.0",
+    version="0.7.1",
     description="Salve is an IPC library that can be used by code editors to easily get autocompletions, replacements, editorconfig suggestions, definitions, and syntax highlighting.",
     author="Moosems",
     author_email="moosems.j@gmail.com",

--- a/tests/test_ipc.py
+++ b/tests/test_ipc.py
@@ -168,11 +168,13 @@ def test_IPC():
 
     assert highlight_output == expected_output
 
-    context.update_file("foo", open(Path("tests/testing_file2.py"), "r+").read())
+    context.update_file(
+        "foo", open(Path("tests/testing_file2.py"), "r+").read()
+    )
     context.request(HIGHLIGHT, file="foo", language="python")
     while not (output := context.get_response(HIGHLIGHT)):
         pass
-    response = output["result"] # type: ignore
+    response = output["result"]  # type: ignore
     assert response != []
 
     context.remove_file("test")

--- a/tests/test_ipc.py
+++ b/tests/test_ipc.py
@@ -168,6 +168,13 @@ def test_IPC():
 
     assert highlight_output == expected_output
 
+    context.update_file("foo", open(Path("tests/testing_file2.py"), "r+").read())
+    context.request(HIGHLIGHT, file="foo", language="python")
+    while not (output := context.get_response(HIGHLIGHT)):
+        pass
+    response = output["result"] # type: ignore
+    assert response != []
+
     context.remove_file("test")
     context.kill_IPC()
 


### PR DESCRIPTION
If no new_tokens existed it would not give out any new tokens since the overwrite method did not have anything to compare against.

Fixes #60.

Changes in PR:
 - simple if statement
 - an or instead of and (separate issue but still another bugfix)
 - Adds another test case