### PR TITLE
Use dirhtml for docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,7 +13,7 @@ build:
   commands:
     - python3 ./docs/source/create_example_docs.py
     - python3 -m pip install -r docs/requirements.txt
-    - python3 -m sphinx docs/source $READTHEDOCS_OUTPUT/html
+    - python3 -m sphinx --builder dirhtml docs/source $READTHEDOCS_OUTPUT/html
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:


### PR DESCRIPTION
Gets rid of the .html at the end of the link