### PR TITLE
Use salve dependency hub

### DIFF
--- a/docs/source/examples/simple_mapping_example.rst
+++ b/docs/source/examples/simple_mapping_example.rst
@@ -6,8 +6,8 @@ Simple Mapping Example
 
     from time import sleep
     
+    from salve_dependency_hub import conversion_dict
     from tree_sitter import Language, Parser, Tree
-    from tree_sitter_python import language
     
     from salve import HIGHLIGHT, IPC, Token, make_unrefined_mapping
     
@@ -43,7 +43,9 @@ Simple Mapping Example
             "type",
         ]
     
-        tree: Tree = Parser(Language(language())).parse(bytes(code, "utf8"))
+        tree: Tree = Parser(Language(conversion_dict["python"]())).parse(
+            bytes(code, "utf8")
+        )
     
         print(
             make_unrefined_mapping(

--- a/docs/source/examples/simple_tree_sitter_highlights_example.rst
+++ b/docs/source/examples/simple_tree_sitter_highlights_example.rst
@@ -6,7 +6,7 @@ Simple Tree Sitter Highlights Example
 
     from time import sleep
     
-    from tree_sitter_python import language
+    from salve_dependency_hub import conversion_dict
     
     from salve import HIGHLIGHT_TREE_SITTER, IPC, Response
     
@@ -55,7 +55,7 @@ Simple Tree Sitter Highlights Example
             file="test",
             language="python",
             text_range=(1, 30),
-            tree_sitter_language=language,
+            tree_sitter_language=conversion_dict["python"],
             mapping=example_mapping,
         )
     

--- a/examples/simple_mapping_example.py
+++ b/examples/simple_mapping_example.py
@@ -1,7 +1,7 @@
 from time import sleep
 
+from salve_dependency_hub import conversion_dict
 from tree_sitter import Language, Parser, Tree
-from tree_sitter_python import language
 
 from salve import HIGHLIGHT, IPC, Token, make_unrefined_mapping
 
@@ -37,7 +37,9 @@ def main():
         "type",
     ]
 
-    tree: Tree = Parser(Language(language())).parse(bytes(code, "utf8"))
+    tree: Tree = Parser(Language(conversion_dict["python"]())).parse(
+        bytes(code, "utf8")
+    )
 
     print(
         make_unrefined_mapping(

--- a/examples/simple_tree_sitter_highlights_example.py
+++ b/examples/simple_tree_sitter_highlights_example.py
@@ -1,6 +1,6 @@
 from time import sleep
 
-from tree_sitter_python import language
+from salve_dependency_hub import conversion_dict
 
 from salve import HIGHLIGHT_TREE_SITTER, IPC, Response
 
@@ -49,7 +49,7 @@ def main():
         file="test",
         language="python",
         text_range=(1, 30),
-        tree_sitter_language=language,
+        tree_sitter_language=conversion_dict["python"],
         mapping=example_mapping,
     )
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@ tree-sitter
 
 # Testing
 pytest
-tree-sitter-python
+salve_dependency_hub
 
 # Formatting
 ruff

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# pip install -r requirements.txt --break-system-packages; pip uninstall salve -y --break-system-packages; pip install . --break-system-packages --no-build-isolation; python3 -m pytest .
+# pip install -U -r requirements-dev.txt --break-system-packages; pip uninstall salve -y --break-system-packages; pip install . --break-system-packages --no-build-isolation; python3 -m pytest .
 from setuptools import setup
 
 with open("README.md", "r") as file:

--- a/tests/test_ipc.py
+++ b/tests/test_ipc.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from sys import platform
 from time import sleep
 
-from tree_sitter_python import language
+from salve_dependency_hub import conversion_dict
 
 from salve import (
     AUTOCOMPLETE,
@@ -75,7 +75,7 @@ def test_IPC():
         HIGHLIGHT_TREE_SITTER,
         file="test",
         language="python",
-        tree_sitter_language=language,
+        tree_sitter_language=conversion_dict["python"],
         mapping=minimal_python_mapping,
         text_range=(1, 18),
     )

--- a/tests/test_tree_sitter.py
+++ b/tests/test_tree_sitter.py
@@ -1,9 +1,8 @@
 from logging import Logger
 
+from beartype.typing import Callable
+from salve_dependency_hub import conversion_dict
 from tree_sitter import Language, Parser, Tree
-from tree_sitter_python import (
-    language as py_language,  # Downloaded automatically by test runners
-)
 
 from salve import make_unrefined_mapping
 from salve.server_functions.highlight.tree_sitter_funcs import (
@@ -81,6 +80,7 @@ code_snippet_output = [
     ((5, 6), 6, "String"),
     ((5, 12), 1, "Punctuation"),
 ]
+py_language: Callable[[], int] = conversion_dict["python"]
 parser: Parser = Parser(
     Language(py_language())
 )  # Will be input along with code snippet


### PR DESCRIPTION
Fixes #65. Closes #65.

Changes in PR:
 - Use salve dependency hub instead of tree_sitter_python